### PR TITLE
fix(schema): fix crash when field doesn't have get_accessor_name method

### DIFF
--- a/django_forest/utils/__init__.py
+++ b/django_forest/utils/__init__.py
@@ -10,7 +10,14 @@ def get_accessor_name(field):
     if isinstance(field, ManyToManyField) or isinstance(field, ForeignKey):
         accessor_name = field.name
     else:
-        accessor_name = field.get_accessor_name()
+        try:
+            accessor_name = field.get_accessor_name()
+        except AttributeError:
+            # Avoid a crash when the field doesn't have a get_accessor_name() method.
+            # Example: it avoids a crash when using a project that uses the
+            # Taggit package: 'TaggableManager' object has no attribute
+            # 'get_accessor_name'
+            return
 
     return accessor_name
 


### PR DESCRIPTION
After generator a new Django project based on Wagtail CMS, Forest Admin crashes when the backend starts.

Stacktrace:
```
Exception in thread django-main-thread:
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.1_6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/threading.py", line 954, in _bootstrap_inner
    self.run()
  File "/usr/local/Cellar/python@3.9/3.9.1_6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/threading.py", line 892, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/seyz/workspace/internal/django-forestadmin/venv/lib/python3.9/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/Users/seyz/workspace/internal/django-forestadmin/django_forest/management/commands/runserver.py", line 15, in inner_run
    Schema.build_schema()
  File "/Users/seyz/workspace/internal/django-forestadmin/django_forest/utils/schema/__init__.py", line 119, in build_schema
    cls.add_fields(model, collection)
  File "/Users/seyz/workspace/internal/django-forestadmin/django_forest/utils/schema/__init__.py", line 109, in add_fields
    f = cls.handle_relation(field, f)
  File "/Users/seyz/workspace/internal/django-forestadmin/django_forest/utils/schema/__init__.py", line 83, in handle_relation
    f['field'] = get_accessor_name(field)
  File "/Users/seyz/workspace/internal/django-forestadmin/django_forest/utils/__init__.py", line 13, in get_accessor_name
    accessor_name = field.get_accessor_name()
AttributeError: 'TaggableManager' object has no attribute 'get_accessor_name'
```