### PR TITLE
fix(schema): log a warning message to avoid a crash when a field type…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ media
 .idea
 *.iws /out/
 
+# If you are using VSCode #
+.vscode
+
 # Python #
 *.py[cod]
 *$py.class

--- a/django_forest/utils/type_mapping.py
+++ b/django_forest/utils/type_mapping.py
@@ -1,3 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
 TYPE_CHOICES = {
     'AutoField': 'String',
     'BigAutoField': 'Integer',
@@ -49,7 +53,12 @@ def get_type(field):
     if hasattr(field, 'choices') and field.choices is not None:
         return 'Enum'
 
-    field_type = field.get_internal_type()
+    try:
+        field_type = field.get_internal_type()
+    except AttributeError:
+        logger.warning("Can't detect the field type of ({})".format(field))
+        return
+
     # Special case for one to one field which can redirect to an Integer or String
     if field_type == 'OneToOneField':
         return handle_one_to_one_field(field)


### PR DESCRIPTION
After generator a new Django project based on Wagtail CMS, Forest Admin crashes when the backend starts.

Stacktrace:
```
Exception in thread django-main-thread:
Traceback (most recent call last):                                                       
  File "/usr/local/Cellar/python@3.9/3.9.1_6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/threading.py", line 954, in _bootstrap_inner                                  
    self.run()                 
  File "/usr/local/Cellar/python@3.9/3.9.1_6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/threading.py", line 892, in run                                               
    self._target(*self._args, **self._kwargs)
  File "/Users/seyz/workspace/internal/django-forestadmin/venv/lib/python3.9/site-packages/django/utils/autoreload.py", line 64, in wrapper                                       
    fn(*args, **kwargs)                    
  File "/Users/seyz/workspace/internal/django-forestadmin/django_forest/management/commands/runserver.py", line 15, in inner_run                                                  
    Schema.build_schema()                                                                                                                                                         
  File "/Users/seyz/workspace/internal/django-forestadmin/django_forest/utils/schema/__init__.py", line 119, in build_schema                                      
    cls.add_fields(model, collection)
  File "/Users/seyz/workspace/internal/django-forestadmin/django_forest/utils/schema/__init__.py", line 104, in add_fields                                                        
    'type': cls.get_type(field)             
  File "/Users/seyz/workspace/internal/django-forestadmin/django_forest/utils/schema/__init__.py", line 94, in get_type                                                           
    type = get_type(field)               
  File "/Users/seyz/workspace/internal/django-forestadmin/django_forest/utils/type_mapping.py", line 52, in get_type                                                              
    field_type = field.get_internal_type()                                               
AttributeError: 'GenericForeignKey' object has no attribute 'get_internal_type' 
```