### PR TITLE
fix(serializer): avoid enforcing 'pk' as a primary key if 'id' is not…

### DIFF
--- a/django_forest/resources/utils/json_api_serializer.py
+++ b/django_forest/resources/utils/json_api_serializer.py
@@ -4,9 +4,7 @@ from django_forest.utils.schema.json_api_schema import JsonApiSchema
 
 class JsonApiSerializerMixin:
     def get_pk_name(self, Model):
-        if Model._meta.pk.name != 'id':
-            return 'pk'
-        return 'id'
+        return Model._meta.pk.name
 
     def compute_only(self, only, field_name, params, Model):
         collection = Schema.get_collection(Model._meta.db_table)

--- a/django_forest/utils/schema/json_api_schema.py
+++ b/django_forest/utils/schema/json_api_schema.py
@@ -55,9 +55,7 @@ def handle_pk_attribute(attrs, Model):
 
 def get_pk_name(collection_name):
     Model = Models.get(collection_name)
-    if Model is not None and Model._meta.pk.name != 'id':
-        return 'pk'
-    return 'id'
+    return Model._meta.pk.name
 
 
 def get_marshmallow_field(field, Model):


### PR DESCRIPTION
Not sure of this fix. But the problem can be reproduced with my project generated using wagtail.
Collections such as `Groupapprovaltasks` or `Home Homepages` crashes because `Model._meta.pk.name` was not returning `id` and hardcoding `pk` made it crash.