### PR TITLE
fix(onboarding): the env variables should override the django settings

### DIFF
--- a/django_forest/tests/utils/test_get_forest_setting.py
+++ b/django_forest/tests/utils/test_get_forest_setting.py
@@ -1,44 +1,72 @@
+import os
+import pytest
 from django.test import TestCase, override_settings
 
 from django_forest.utils.forest_setting import get_forest_setting
 
-from test.support import EnvironmentVarGuard
-
 
 class UtilsCorsTests(TestCase):
-
-    def setUp(self):
-        self.env = EnvironmentVarGuard()
-        self.env.set('BAR', 'bar')
-
-    @override_settings(FOREST={'FOO': 'foo'})
+    
+    @override_settings(
+        FOREST={
+            'FOO': 'foo',
+            'BAR': 'bar'
+    })
     def test_get_forest_setting(self):
-        foo = get_forest_setting('FOO')
-        self.assertEqual(foo, 'foo')
-
-    def test_get_forest_setting_none(self):
-        foo = get_forest_setting('FOO')
-        self.assertEqual(foo, None)
-
+        self.assertEqual(
+            get_forest_setting('FOO'), 
+            'foo',
+        )
+        self.assertEqual(
+            get_forest_setting('BAR'), 
+            'bar',
+        )
+        self.assertEqual(
+            get_forest_setting('UNKNOWN'), 
+            None,
+        )
+    
+    @override_settings(
+        FOREST={
+            'FOO': 'foo',
+            'BAR': 'False'
+    })
     def test_get_forest_setting_default(self):
-        foo = get_forest_setting('FOO', True)
-        self.assertEqual(foo, True)
+        self.assertEqual(
+            get_forest_setting('FOO', 'default'), 
+            'foo'
+        )
+        self.assertEqual(
+            get_forest_setting('FOO', True), 
+            True,
+        )
+        self.assertEqual(
+            get_forest_setting('BAR', True), 
+            False
+        )
+        self.assertEqual(
+            get_forest_setting('Unknown', True), 
+            True
+        )
 
-    @override_settings(FOREST={'FOO': 'True'})
-    def test_get_forest_setting_bool(self):
-        foo = get_forest_setting('FOO', False)
-        self.assertEqual(foo, True)
-
-    @override_settings(FOREST={'FOO': 'foo'})
-    def test_get_forest_setting_bad_bool(self):
-        foo = get_forest_setting('FOO', False)
-        self.assertEqual(foo, False)
-
+    @override_settings(
+        FOREST={
+            'FOO': 'foo',
+            'BAR': 'bar'
+    })
     def test_get_forest_setting_env(self):
-        bar = get_forest_setting('BAR')
-        self.assertEqual(bar, 'bar')
+        os.environ['FOO'] = 'envfoo'
+        self.assertEqual(
+            get_forest_setting('FOO'), 
+            'envfoo'
+        )
+        self.assertEqual(
+            get_forest_setting('BAR'), 
+            'bar'
+        )
+        os.environ['BOOL'] = 'False'
+        self.assertEqual(
+            get_forest_setting('BOOL', True), 
+            False
+        )
 
-    @override_settings(FOREST={'BAR': 'new_bar'})
-    def test_get_forest_setting_env_setting(self):
-        bar = get_forest_setting('BAR')
-        self.assertEqual(bar, 'new_bar')

--- a/django_forest/utils/forest_setting.py
+++ b/django_forest/utils/forest_setting.py
@@ -5,8 +5,8 @@ from django.conf import settings
 
 
 def get_forest_setting(setting, default=None):
-    env_setting = os.getenv(setting, default)
-    forest_setting = getattr(settings, 'FOREST', {}).get(setting, env_setting)
+    django_settings = getattr(settings, 'FOREST', {}).get(setting, default)
+    forest_setting = os.getenv(setting, django_settings)
     if isinstance(default, bool) and isinstance(forest_setting, str):
         try:
             forest_setting = strtobool(forest_setting)


### PR DESCRIPTION
To onboard a client we set some forest settings in the settings.py (FOREST_ENV_SECRET, etc.). To push in production we override these settings with env variable.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
