### PR TITLE
fix(dashboard): use a related field as group_by aggregate was broken

### DIFF
--- a/django_forest/middleware/permissions.py
+++ b/django_forest/middleware/permissions.py
@@ -54,6 +54,9 @@ class PermissionMiddleware:
         elif permission_name in 'statsWithParameters':
             if 'timezone' in body:
                 del body['timezone']
+            if 'group_by_field' in body:
+                #  usefull if the group_by_field is a related field
+                body['group_by_field'] = body['group_by_field'].split(':')[0]
             kwargs['query_request_info'] = body
 
     def is_authorized(self, request, token, resource):


### PR DESCRIPTION
When a user set a related field as group_by aggregator the agent returned a 403

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made
