### PR TITLE
fix(onboarding): the settings 'middleware' and 'installed_apps' should be lists

### DIFF
--- a/django_forest/utils/cors.py
+++ b/django_forest/utils/cors.py
@@ -10,9 +10,11 @@ def get_list_setting(setting):
 
 def set_cors():
 
+    settings.INSTALLED_APPS = list(settings.INSTALLED_APPS)
     if 'corsheaders' not in settings.INSTALLED_APPS:
         settings.INSTALLED_APPS += ['corsheaders']
 
+    settings.MIDDLEWARE = list(settings.MIDDLEWARE)
     if 'corsheaders.middleware.CorsMiddleware' not in settings.MIDDLEWARE:
         try:
             common_middleware_index = settings.MIDDLEWARE.index('django.middleware.common.CommonMiddleware')


### PR DESCRIPTION

The django settings may have all the iterable's types. To hanle them we cast them to list.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made
