### PR TITLE
feat(filter): add support for case insensitive filter and search

### DIFF
--- a/django_forest/resources/utils/queryset/filters/utils.py
+++ b/django_forest/resources/utils/queryset/filters/utils.py
@@ -2,33 +2,35 @@ from django.db.models import Q
 
 from django_forest.resources.utils.queryset.filters.date import DatesMixin
 from django_forest.resources.utils.queryset.filters.date.factory import ConditionFactory as DateConditionFactory
-from django_forest.utils import get_association_field
+from django_forest.utils import get_association_field, get_forest_setting
 from django_forest.utils.type_mapping import get_type
 from django_forest.utils.collection import Collection
 from django_forest.utils.schema import Schema
 
 
-OPERATORS = {
-    'not': '',
-    'contains': '__contains',
-    'not_contains': '__contains',
-    'before': '__lt',
-    'less_than': '__lt',
-    'after': '__gt',
-    'greater_than': '__gt',
-    'starts_with': '__startswith',
-    'ends_with': '__endswith',
-    'not_equal': '',
-    'equal': '',
-    'includes_all': '__contains',
-    'in': '__in',
-}
+def get_operators():
+    case_insensitive = get_forest_setting('FOREST_CASE_INSENSITIVE_FILTER', False)
+    return {
+        'not': '__iexact' if case_insensitive else '',
+        'contains': '__icontains' if case_insensitive else '__contains',
+        'not_contains': '__icontains' if case_insensitive else '__contains',
+        'before': '__lt',
+        'less_than': '__lt',
+        'after': '__gt',
+        'greater_than': '__gt',
+        'starts_with': '__istartswith' if case_insensitive else '__startswith',
+        'ends_with': '__iendswith' if case_insensitive else '__endswith',
+        'not_equal': '__iexact' if case_insensitive else '',
+        'equal': '__iexact' if case_insensitive else '',
+        'includes_all': '__icontains' if case_insensitive else '__contains',
+        'in': '__in',
+    }
 
 
 class ConditionsMixin(DatesMixin):
     def get_basic_expression(self, field, operator, value):
         try:
-            lookup_field = f"{field}{OPERATORS[operator]}"
+            lookup_field = f"{field}{get_operators()[operator]}"
         except Exception:
             raise Exception(f'Unknown provided operator {operator}')
         else:

--- a/django_forest/resources/utils/queryset/search.py
+++ b/django_forest/resources/utils/queryset/search.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from django.db.models import Q
 
+from django_forest.utils import get_forest_setting
 from django_forest.utils.collection import Collection
 from ..in_search_fields import in_search_fields
 from django_forest.utils.schema import Schema
@@ -61,7 +62,8 @@ class SearchMixin:
         if is_uuid:
             q_object = Q(**{lookup_field: search})
         else:
-            q_object = Q(**{f'{lookup_field}__contains': search})
+            lookup_type = "icontains" if get_forest_setting('FOREST_CASE_INSENSITIVE_FILTER', False) else "contains"
+            q_object = Q(**{f'{lookup_field}__{lookup_type}': search})
 
         return q_object
 

--- a/django_forest/tests/forest/question.py
+++ b/django_forest/tests/forest/question.py
@@ -89,8 +89,8 @@ class QuestionForest(Collection):
         return Q(question_text=search)
 
     def filter_foo(self, operator, value):
-        from django_forest.resources.utils.queryset.filters.utils import OPERATORS
-        kwargs = {f'question_text{OPERATORS[operator]}': value}
+        from django_forest.resources.utils.queryset.filters.utils import get_operators
+        kwargs = {f'question_text{get_operators()[operator]}': value}
         is_negated = operator.startswith('not')
         if is_negated:
             return ~Q(**kwargs)
@@ -107,8 +107,8 @@ class QuestionForest(Collection):
         return Q(question_text=search)
 
     def filter_bar(self, operator, value):
-        from django_forest.resources.utils.queryset.filters.utils import OPERATORS
-        kwargs = {f'question_text{OPERATORS[operator]}': value}
+        from django_forest.resources.utils.queryset.filters.utils import get_operators
+        kwargs = {f'question_text{get_operators()[operator]}': value}
         is_negated = operator.startswith('not')
         if is_negated:
             return ~Q(**kwargs)

--- a/django_forest/tests/resources/views/list/test_list_filters.py
+++ b/django_forest/tests/resources/views/list/test_list_filters.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 import pytz
-from django.test import TransactionTestCase
+from django.test import TransactionTestCase, override_settings
 from django.urls import reverse
 
 from django_forest.tests.fixtures.schema import test_schema
@@ -46,6 +46,43 @@ class ResourceListFilterViewTests(TransactionTestCase):
             'fields[tests_question]': 'id,topic,question_text,pub_date',
             'fields[topic]': 'name',
             'filters': '{"field":"question_text","operator":"equal","value":"what is your favorite color?"}',
+            'timezone': 'Europe/Paris',
+            'page[number]': '1',
+            'page[size]': '15'
+        })
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data, {
+            'data': [
+                {
+                    'type': 'tests_question',
+                    'id': 1,
+                    'attributes': {
+                        'pub_date': '2021-06-02T13:52:53.528000+00:00',
+                        'question_text': 'what is your favorite color?'
+                    },
+                    'links': {
+                        'self': '/forest/tests_question/1'
+                    },
+                    'relationships': {
+                        'topic': {
+                            'data': None,
+                            'links': {
+                                'related': '/forest/tests_question/1/relationships/topic'
+                            }
+                        }
+                    },
+                }
+            ]
+        })
+
+    @override_settings(FOREST={'FOREST_CASE_INSENSITIVE_FILTER': True})
+    @mock.patch('jose.jwt.decode', return_value={'id': 1, 'rendering_id': 1})
+    def test_case_insensitive_is(self, mocked_datetime, *args, **kwargs):
+        response = self.client.get(self.url, {
+            'fields[tests_question]': 'id,topic,question_text,pub_date',
+            'fields[topic]': 'name',
+            'filters': '{"field":"question_text","operator":"equal","value":"What is your favorite Color?"}',
             'timezone': 'Europe/Paris',
             'page[number]': '1',
             'page[size]': '15'
@@ -173,6 +210,62 @@ class ResourceListFilterViewTests(TransactionTestCase):
             'fields[tests_question]': 'id,topic,question_text,pub_date',
             'fields[topic]': 'name',
             'filters': '{"field":"question_text","operator":"not","value":"what is your favorite color?"}',
+            'timezone': 'Europe/Paris',
+            'page[number]': '1',
+            'page[size]': '15'
+        })
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data, {
+            'data': [
+                {
+                    'type': 'tests_question',
+                    'attributes': {
+                        'pub_date': '2021-06-02T15:52:53.528000+00:00',
+                        'question_text': 'do you like chocolate?'
+                    },
+                    'id': 2,
+                    'links': {
+                        'self': '/forest/tests_question/2'
+                    },
+                    'relationships': {
+                        'topic': {
+                            'data': None,
+                            'links': {
+                                'related': '/forest/tests_question/2/relationships/topic'
+                            }
+                        }
+                    },
+                },
+                {
+                    'type': 'tests_question',
+                    'attributes': {
+                        'pub_date': '2021-06-03T13:52:53.528000+00:00',
+                        'question_text': 'who is your favorite singer?'
+                    },
+                    'id': 3,
+                    'links': {
+                        'self': '/forest/tests_question/3'
+                    },
+                    'relationships': {
+                        'topic': {
+                            'data': None,
+                            'links': {
+                                'related': '/forest/tests_question/3/relationships/topic'
+                            }
+                        }
+                    },
+                }
+            ]
+        })
+
+    @override_settings(FOREST={'FOREST_CASE_INSENSITIVE_FILTER': True})
+    @mock.patch('jose.jwt.decode', return_value={'id': 1, 'rendering_id': 1})
+    def test_case_insensitive_is_not(self, *args, **kwargs):
+        response = self.client.get(self.url, {
+            'fields[tests_question]': 'id,topic,question_text,pub_date',
+            'fields[topic]': 'name',
+            'filters': '{"field":"question_text","operator":"not","value":"What is your favorite Color?"}',
             'timezone': 'Europe/Paris',
             'page[number]': '1',
             'page[size]': '15'

--- a/django_forest/tests/settings.py
+++ b/django_forest/tests/settings.py
@@ -132,7 +132,8 @@ FOREST = {
     # 'INCLUDED_MODELS': [],
     # 'EXCLUDED_MODELS': ['Permission', 'Group', 'User', 'ContentType'],
     # 'CONFIG_DIR': 'forest',
-    # 'FOREST_DISABLE_AUTO_SCHEMA_APPLY': True
+    # 'FOREST_DISABLE_AUTO_SCHEMA_APPLY': True,
+    # 'FOREST_CASE_INSENSITIVE_FILTER': True
 }
 
 APPEND_SLASH = False


### PR DESCRIPTION
Configuring Forest Admin to support case insensitive filtering exists for [Express.js apps](https://docs.forestadmin.com/woodshop/how-tos/make-filters-case-insensitive), but it's not currently supported in Django.

This PR adds a Forest settings `FOREST_CASE_INSENSITIVE_FILTER` to enable case insensitivity for filter and search.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made