### PR TITLE
fix(authentication): add skew to id_token iat verification

### DIFF
--- a/django_forest/authentication/views/callback.py
+++ b/django_forest/authentication/views/callback.py
@@ -92,7 +92,8 @@ class CallbackView(View):
             scope=['openid', 'email', 'profile'],
             authn_method='',
             request_args={'code': code},
-            verify=False
+            verify=False,
+            skew=5
         )
         rendering_id = state['renderingId']
         route = f'/liana/v2/renderings/{rendering_id}/authorization'


### PR DESCRIPTION
## Definition of Done

Fixes https://github.com/ForestAdmin/django-forestadmin/issues/108 where a race condition intermittently throws an exception during authentication due to the id_token `iat` being slightly in the future.

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made
