### PR TITLE
Bug/issue 115/smart fields always calculated

### DIFF
--- a/django_forest/resources/associations/views/csv.py
+++ b/django_forest/resources/associations/views/csv.py
@@ -3,6 +3,7 @@ import csv
 from django_forest.resources.associations.utils import AssociationView
 from django_forest.resources.utils.csv import CsvMixin
 from django_forest.resources.utils.json_api_serializer import JsonApiSerializerMixin
+from django_forest.resources.utils.query_parameters import parse_qs
 from django_forest.resources.utils.smart_field import SmartFieldMixin
 from django_forest.utils import get_association_field
 
@@ -24,7 +25,7 @@ class CsvView(SmartFieldMixin, JsonApiSerializerMixin, CsvMixin, AssociationView
             queryset = self.enhance_queryset(queryset, RelatedModel, params, request)
 
             # handle smart fields
-            self.handle_smart_fields(queryset, RelatedModel._meta.db_table, many=True)
+            self.handle_smart_fields(queryset, RelatedModel._meta.db_table, parse_qs(params), many=True)
 
             # json api serializer
             data = self.serialize(queryset, RelatedModel, params)

--- a/django_forest/resources/associations/views/list.py
+++ b/django_forest/resources/associations/views/list.py
@@ -4,6 +4,7 @@ from django.http import JsonResponse, HttpResponse
 
 from django_forest.resources.associations.utils import AssociationView
 from django_forest.resources.utils.json_api_serializer import JsonApiSerializerMixin
+from django_forest.resources.utils.query_parameters import parse_qs
 from django_forest.resources.utils.smart_field import SmartFieldMixin
 from django_forest.utils import get_association_field
 
@@ -26,7 +27,7 @@ class ListView(SmartFieldMixin, JsonApiSerializerMixin, AssociationView):
             queryset = self.enhance_queryset(queryset, RelatedModel, params, request)
 
             # handle smart fields
-            self.handle_smart_fields(queryset, RelatedModel._meta.db_table, many=True)
+            self.handle_smart_fields(queryset, RelatedModel._meta.db_table, parse_qs(params), many=True)
 
             # json api serializer
             data = self.serialize(queryset, RelatedModel, params)

--- a/django_forest/resources/utils/smart_field.py
+++ b/django_forest/resources/utils/smart_field.py
@@ -24,23 +24,20 @@ class SmartFieldMixin:
         for smart_field in smart_fields:
             self._handle_get_method(smart_field, item, resource)
 
-    def _get_smart_fields_for_request(self, collection, params):
+    def _get_smart_fields_for_request(self, collection, params=None):
 
-        def is_virtual(field):
-            return field.get('is_virtual')
+        fields = [field for field in collection['fields'] if field['is_virtual']]
 
-        def include_field(field, required_fields):
-            return is_virtual(field) and field['field'] in required_fields
+        if params is None:
+            return fields
 
-        # Either none provided, or a list of smart field names
-        queried_fields = (params or {}).get('fields', {}).get(collection.get('name'))
+        filtered_fields = params.get('fields', {}).get(collection.get('name'))
+        if filtered_fields is None:
+            return fields
 
-        if queried_fields is None:
-            return [field for field in collection['fields'] if is_virtual(field)]
+        return [field for field in fields if field['field'] in filtered_fields]
 
-        return [field for field in collection['fields'] if include_field(field, set(queried_fields))]
-
-    def handle_smart_fields(self, queryset, resource, params, many=False):
+    def handle_smart_fields(self, queryset, resource, params=None, many=False):
         collection = Schema.get_collection(resource)
 
         # Rather than calculate and then filter out smart fields, we want to ignore them entirely

--- a/django_forest/resources/utils/smart_field.py
+++ b/django_forest/resources/utils/smart_field.py
@@ -24,13 +24,33 @@ class SmartFieldMixin:
         for smart_field in smart_fields:
             self._handle_get_method(smart_field, item, resource)
 
-    def handle_smart_fields(self, queryset, resource, many=False):
+    def _get_smart_fields_for_request(self, collection, params):
+
+        def is_virtual(field):
+            return field.get('is_virtual')
+
+        def include_field(field, required_fields):
+            return is_virtual(field) and field['field'] in required_fields
+
+        # Either none provided, or a list of smart field names
+        queried_fields = (params or {}).get('fields', {}).get(collection.get('name'))
+
+        if queried_fields is None:
+            return [field for field in collection['fields'] if is_virtual(field)]
+
+        return [field for field in collection['fields'] if include_field(field, set(queried_fields))]
+
+    def handle_smart_fields(self, queryset, resource, params, many=False):
         collection = Schema.get_collection(resource)
-        smart_fields = [x for x in collection['fields'] if x['is_virtual']]
-        if many:
+
+        # Rather than calculate and then filter out smart fields, we want to ignore them entirely
+        smart_fields = self._get_smart_fields_for_request(collection, params)
+
+        # Don't bother adding anything if there are no smart fields
+        if smart_fields and many:
             for item in queryset:
                 self._add_smart_fields(item, smart_fields, resource)
-        else:
+        elif smart_fields:
             self._add_smart_fields(queryset, smart_fields, resource)
 
     def update_smart_fields(self, instance, body, resource):

--- a/django_forest/resources/views/csv.py
+++ b/django_forest/resources/views/csv.py
@@ -3,6 +3,7 @@ import csv
 from django_forest.resources.utils.csv import CsvMixin
 from django_forest.resources.utils.format import FormatFieldMixin
 from django_forest.resources.utils.json_api_serializer import JsonApiSerializerMixin
+from django_forest.resources.utils.query_parameters import parse_qs
 from django_forest.resources.utils.resource import ResourceView
 from django_forest.resources.utils.smart_field import SmartFieldMixin
 
@@ -19,7 +20,7 @@ class CsvView(FormatFieldMixin, SmartFieldMixin, JsonApiSerializerMixin, CsvMixi
             queryset = self.enhance_queryset(queryset, self.Model, params, request)
 
             # handle smart fields
-            self.handle_smart_fields(queryset, self.Model._meta.db_table, many=True)
+            self.handle_smart_fields(queryset, self.Model._meta.db_table, parse_qs(params), many=True)
 
             # json api serializer
             data = self.serialize(queryset, self.Model, params)

--- a/django_forest/resources/views/detail.py
+++ b/django_forest/resources/views/detail.py
@@ -24,7 +24,7 @@ class DetailView(SmartFieldMixin, FormatFieldMixin, JsonApiSerializerMixin, Reso
 
         instance = queryset[0]
         # handle smart fields
-        self.handle_smart_fields(instance, self.Model._meta.db_table)
+        self.handle_smart_fields(instance, self.Model._meta.db_table, None)
 
         return instance
 
@@ -35,7 +35,7 @@ class DetailView(SmartFieldMixin, FormatFieldMixin, JsonApiSerializerMixin, Reso
             return self.error_response(e)
         else:
             # handle smart fields
-            self.handle_smart_fields(instance, self.Model._meta.db_table)
+            self.handle_smart_fields(instance, self.Model._meta.db_table, None)
 
             # json api serializer
             include_data = self.get_include_data(Schema.get_collection(self.Model._meta.db_table)['fields'])

--- a/django_forest/resources/views/detail.py
+++ b/django_forest/resources/views/detail.py
@@ -24,7 +24,7 @@ class DetailView(SmartFieldMixin, FormatFieldMixin, JsonApiSerializerMixin, Reso
 
         instance = queryset[0]
         # handle smart fields
-        self.handle_smart_fields(instance, self.Model._meta.db_table, None)
+        self.handle_smart_fields(instance, self.Model._meta.db_table)
 
         return instance
 
@@ -35,7 +35,7 @@ class DetailView(SmartFieldMixin, FormatFieldMixin, JsonApiSerializerMixin, Reso
             return self.error_response(e)
         else:
             # handle smart fields
-            self.handle_smart_fields(instance, self.Model._meta.db_table, None)
+            self.handle_smart_fields(instance, self.Model._meta.db_table)
 
             # json api serializer
             include_data = self.get_include_data(Schema.get_collection(self.Model._meta.db_table)['fields'])

--- a/django_forest/resources/views/list.py
+++ b/django_forest/resources/views/list.py
@@ -2,6 +2,7 @@ from django.http import JsonResponse, HttpResponse
 
 from django_forest.resources.utils.format import FormatFieldMixin
 from django_forest.resources.utils.json_api_serializer import JsonApiSerializerMixin
+from django_forest.resources.utils.query_parameters import parse_qs
 from django_forest.resources.utils.resource import ResourceView
 from django_forest.resources.utils.smart_field import SmartFieldMixin
 from django_forest.utils.schema.json_api_schema import JsonApiSchema
@@ -19,7 +20,7 @@ class ListView(FormatFieldMixin, SmartFieldMixin, JsonApiSerializerMixin, Resour
             queryset = self.enhance_queryset(queryset, self.Model, params, request)
 
             # handle smart fields
-            self.handle_smart_fields(queryset, self.Model._meta.db_table, many=True)
+            self.handle_smart_fields(queryset, self.Model._meta.db_table, parse_qs(params), many=True)
 
             # json api serializer
             data = self.serialize(queryset, self.Model, params)


### PR DESCRIPTION
This PR aims to address Issue #115 where smart fields would be filtered out of a response, but only after being evaluated. This put our API under great load, so rather than just calculate and then filter, this change will just ignore smart fields that weren't requested.

A [support ticked](https://community.forestadmin.com/t/dont-load-smart-field-in-collection-view/5102) was also raised.