### PR TITLE
Resolve issue where action name was not being respected for hooks

### DIFF
--- a/django_forest/actions/hooks/views/utils.py
+++ b/django_forest/actions/hooks/views/utils.py
@@ -1,6 +1,3 @@
-from functools import reduce
-from itertools import chain
-
 from django.http import JsonResponse, HttpResponse
 
 from django_forest.utils import get_token

--- a/django_forest/tests/forest/question.py
+++ b/django_forest/tests/forest/question.py
@@ -31,12 +31,6 @@ class QuestionForest(Collection):
 
         self.actions = [
             {
-                'name': 'Mark as Live'
-            }, {
-                'name': 'Generate invoice',
-                'download': True,  # If true, the action triggers a file download in the Browser.
-            },
-            {
                 'name': 'Send invoice',
                 'type': 'single',
                 'fields': [
@@ -68,7 +62,13 @@ class QuestionForest(Collection):
                         'zipCodeChange': self.invoice_change_zip_code,
                     },
                 },
-            }
+            },
+            {
+                'name': 'Mark as Live'
+            }, {
+                'name': 'Generate invoice',
+                'download': True,  # If true, the action triggers a file download in the Browser.
+            },
         ]
 
         self.segments = [


### PR DESCRIPTION
This PR resolves issue #117 where actions were being looped over indefinitely to resolve their hooks. The test was easily falsifiable by changing the order in which the actions were registered in the relevant Model Forest classes.