### PR TITLE
feat: implement FOREST_DISABLE_AUTO_SCHEMA_UPDATE and test for it

### DIFF
--- a/django_forest/utils/schema/__init__.py
+++ b/django_forest/utils/schema/__init__.py
@@ -161,8 +161,10 @@ class Schema:
             for index, collection in enumerate(cls.schema_data['collections']):
                 cls.schema_data['collections'][index] = cls.get_serialized_collection(collection)
 
-            with open(file_path, 'w') as f:
-                f.write(json.dumps(cls.schema_data, indent=2))
+            disable_auto_schema_update = get_forest_setting('FOREST_DISABLE_AUTO_SCHEMA_UPDATE', False)
+            if not disable_auto_schema_update:
+                with open(file_path, 'w') as f:
+                    f.write(json.dumps(cls.schema_data, indent=2))
         else:
             cls.handle_schema_file_production(file_path)
 


### PR DESCRIPTION
## Definition of Done
- Added support for a new optional setting `FOREST_DISABLE_AUTO_SCHEMA_UPDATE` which, if true, will stop the `forestadmin-schema.json` to be overwritten but still generating schema data for the app to function properly
- It only applies in the scenario where the file is written, i.e. if `DEBUG = true`
- Wrote test for it, following standards
  - Corrected a few usages of `self.assertRaises` in other tests in the file wich were not being used properly

## Note
I didn't add anything in the changelog or versioning because I'm less familiar with it, and I'm not sure if you're the ones to add those changes when releasing it! So let me know if I should add anything

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made
